### PR TITLE
Add German news articles for September 21, 2025

### DIFF
--- a/articles/2025-09-21/frauen-proteste-berlin-landtag.json
+++ b/articles/2025-09-21/frauen-proteste-berlin-landtag.json
@@ -1,0 +1,122 @@
+{
+  "title": "Frauen protestieren im Berliner Landtag gegen Haushaltskürzungen",
+  "translated_title": "Women protest in Berlin state parliament against budget cuts",
+  "text": [
+    {
+      "text": "Mehrere Dutzend Frauen haben das Berliner Landtagsgebäude besetzt.",
+      "translated_text": "Several dozen women have occupied the Berlin state parliament building."
+    },
+    {
+      "text": "Sie protestierten gegen geplante Kürzungen im Haushaltsplan der Berliner Regierung.",
+      "translated_text": "They protested against planned cuts in the budget plan of the Berlin government."
+    },
+    {
+      "text": "Die Frauen besetzten eine der Eingangshallen-Treppen des Parlamentsgebäudes.",
+      "translated_text": "The women occupied one of the entrance hall staircases of the parliament building."
+    },
+    {
+      "text": "Besonders betroffen sind Projekte, die Frauen unterstützen.",
+      "translated_text": "Projects that support women are particularly affected."
+    },
+    {
+      "text": "Die Demonstrantinnen fordern mehr Geld für Frauenrechte und -projekte.",
+      "translated_text": "The female demonstrators demand more money for women's rights and projects."
+    },
+    {
+      "text": "Der Berliner Senat plant, weniger Geld für soziale Programme auszugeben.",
+      "translated_text": "The Berlin Senate plans to spend less money on social programs."
+    },
+    {
+      "text": "Viele Frauenorganisationen sind von den Kürzungen bedroht.",
+      "translated_text": "Many women's organizations are threatened by the cuts."
+    },
+    {
+      "text": "Die Proteste zeigen, wie wichtig diese Programme für die Gesellschaft sind.",
+      "translated_text": "The protests show how important these programs are for society."
+    },
+    {
+      "text": "Die Frauen bleiben so lange im Landtag, bis ihre Stimme gehört wird.",
+      "translated_text": "The women remain in the state parliament until their voice is heard."
+    },
+    {
+      "text": "Politiker müssen jetzt über alternative Finanzierungsmöglichkeiten nachdenken.",
+      "translated_text": "Politicians must now think about alternative financing possibilities."
+    }
+  ],
+  "key_vocab": [
+    {
+      "term": "protestieren",
+      "translated_term": "to protest",
+      "example_usage": "Sie protestierten gegen geplante Kürzungen im Haushaltsplan der Berliner Regierung."
+    },
+    {
+      "term": "besetzen",
+      "translated_term": "to occupy",
+      "example_usage": "Mehrere Dutzend Frauen haben das Berliner Landtagsgebäude besetzt."
+    },
+    {
+      "term": "die Kürzung",
+      "translated_term": "cut, reduction",
+      "example_usage": "Sie protestierten gegen geplante Kürzungen im Haushaltsplan der Berliner Regierung."
+    },
+    {
+      "term": "der Haushaltsplan",
+      "translated_term": "budget plan",
+      "example_usage": "Sie protestierten gegen geplante Kürzungen im Haushaltsplan der Berliner Regierung."
+    },
+    {
+      "term": "die Eingangshalle",
+      "translated_term": "entrance hall",
+      "example_usage": "Die Frauen besetzten eine der Eingangshallen-Treppen des Parlamentsgebäudes."
+    },
+    {
+      "term": "die Demonstrantin",
+      "translated_term": "female demonstrator",
+      "example_usage": "Die Demonstrantinnen fordern mehr Geld für Frauenrechte und -projekte."
+    },
+    {
+      "term": "die Frauenrechte",
+      "translated_term": "women's rights",
+      "example_usage": "Die Demonstrantinnen fordern mehr Geld für Frauenrechte und -projekte."
+    },
+    {
+      "term": "der Senat",
+      "translated_term": "senate",
+      "example_usage": "Der Berliner Senat plant, weniger Geld für soziale Programme auszugeben."
+    },
+    {
+      "term": "bedroht",
+      "translated_term": "threatened",
+      "example_usage": "Viele Frauenorganisationen sind von den Kürzungen bedroht."
+    },
+    {
+      "term": "die Finanzierungsmöglichkeit",
+      "translated_term": "financing possibility",
+      "example_usage": "Politiker müssen jetzt über alternative Finanzierungsmöglichkeiten nachdenken."
+    }
+  ],
+  "tags": [
+    {
+      "name": "Proteste",
+      "translated_name": "Protests"
+    },
+    {
+      "name": "Berlin",
+      "translated_name": "Berlin"
+    },
+    {
+      "name": "Menschenrechte",
+      "translated_name": "Human Rights"
+    }
+  ],
+  "sources": [
+    {
+      "name": "Tagesspiegel Berlin",
+      "link_url": "https://www.tagesspiegel.de/berlin/"
+    },
+    {
+      "name": "RBB24",
+      "link_url": "https://www.rbb24.de/"
+    }
+  ]
+}

--- a/articles/2025-09-21/polizei-rechtsextremisten-razzia.json
+++ b/articles/2025-09-21/polizei-rechtsextremisten-razzia.json
@@ -1,0 +1,122 @@
+{
+  "title": "Polizei durchsucht Häuser von Rechtsextremisten in Deutschland",
+  "translated_title": "Police search houses of right-wing extremists in Germany",
+  "text": [
+    {
+      "text": "Die deutsche Polizei hat am Dienstag Häuser in mehreren Bundesländern durchsucht.",
+      "translated_text": "German police searched houses in several federal states on Tuesday."
+    },
+    {
+      "text": "Die Razzia richtete sich gegen eine rechtsextremistische Gruppe.",
+      "translated_text": "The raid was directed against a right-wing extremist group."
+    },
+    {
+      "text": "Die Polizei vermutet, dass die Gruppe automatische Waffen besitzt.",
+      "translated_text": "Police suspect that the group possesses automatic weapons."
+    },
+    {
+      "text": "Acht Verdächtige stehen unter Untersuchung.",
+      "translated_text": "Eight suspects are under investigation."
+    },
+    {
+      "text": "Die Durchsuchungen fanden in Niedersachsen, Baden-Württemberg und Nordrhein-Westfalen statt.",
+      "translated_text": "The searches took place in Lower Saxony, Baden-Württemberg and North Rhine-Westphalia."
+    },
+    {
+      "text": "Spezialeinheiten der Polizei waren an der Aktion beteiligt.",
+      "translated_text": "Police special units were involved in the operation."
+    },
+    {
+      "text": "Rechtsextremismus ist ein wachsendes Problem in Deutschland.",
+      "translated_text": "Right-wing extremism is a growing problem in Germany."
+    },
+    {
+      "text": "Die Behörden nehmen solche Gruppen sehr ernst.",
+      "translated_text": "The authorities take such groups very seriously."
+    },
+    {
+      "text": "Der Besitz von automatischen Waffen ist in Deutschland illegal.",
+      "translated_text": "Possession of automatic weapons is illegal in Germany."
+    },
+    {
+      "text": "Die Ermittlungen gegen die Gruppe dauern noch an.",
+      "translated_text": "The investigations against the group are still ongoing."
+    }
+  ],
+  "key_vocab": [
+    {
+      "term": "durchsuchen",
+      "translated_term": "to search",
+      "example_usage": "Die deutsche Polizei hat am Dienstag Häuser in mehreren Bundesländern durchsucht."
+    },
+    {
+      "term": "das Bundesland",
+      "translated_term": "federal state",
+      "example_usage": "Die deutsche Polizei hat am Dienstag Häuser in mehreren Bundesländern durchsucht."
+    },
+    {
+      "term": "die Razzia",
+      "translated_term": "raid",
+      "example_usage": "Die Razzia richtete sich gegen eine rechtsextremistische Gruppe."
+    },
+    {
+      "term": "rechtsextremistisch",
+      "translated_term": "right-wing extremist",
+      "example_usage": "Die Razzia richtete sich gegen eine rechtsextremistische Gruppe."
+    },
+    {
+      "term": "vermuten",
+      "translated_term": "to suspect",
+      "example_usage": "Die Polizei vermutet, dass die Gruppe automatische Waffen besitzt."
+    },
+    {
+      "term": "automatische Waffen",
+      "translated_term": "automatic weapons",
+      "example_usage": "Die Polizei vermutet, dass die Gruppe automatische Waffen besitzt."
+    },
+    {
+      "term": "der Verdächtige",
+      "translated_term": "suspect",
+      "example_usage": "Acht Verdächtige stehen unter Untersuchung."
+    },
+    {
+      "term": "die Spezialeinheit",
+      "translated_term": "special unit",
+      "example_usage": "Spezialeinheiten der Polizei waren an der Aktion beteiligt."
+    },
+    {
+      "term": "die Behörde",
+      "translated_term": "authority",
+      "example_usage": "Die Behörden nehmen solche Gruppen sehr ernst."
+    },
+    {
+      "term": "die Ermittlung",
+      "translated_term": "investigation",
+      "example_usage": "Die Ermittlungen gegen die Gruppe dauern noch an."
+    }
+  ],
+  "tags": [
+    {
+      "name": "Extremismus",
+      "translated_name": "Extremism"
+    },
+    {
+      "name": "Deutsche Politik",
+      "translated_name": "German Politics"
+    },
+    {
+      "name": "Sicherheit",
+      "translated_name": "Security"
+    }
+  ],
+  "sources": [
+    {
+      "name": "Deutsche Welle",
+      "link_url": "http://www.dw-world.de/"
+    },
+    {
+      "name": "Al Jazeera Germany",
+      "link_url": "https://www.aljazeera.com/where/germany/"
+    }
+  ]
+}

--- a/articles/2025-09-21/russland-ukraine-angriff.json
+++ b/articles/2025-09-21/russland-ukraine-angriff.json
@@ -1,0 +1,122 @@
+{
+  "title": "Russland startet großen Angriff auf Ukraine - NATO reagiert",
+  "translated_title": "Russia launches large attack on Ukraine - NATO reacts",
+  "text": [
+    {
+      "text": "Russland hat heute einen großen Angriff auf die Ukraine gestartet.",
+      "translated_text": "Russia launched a large attack on Ukraine today."
+    },
+    {
+      "text": "Die russischen Streitkräfte griffen verschiedene Städte in der Ukraine an.",
+      "translated_text": "Russian forces attacked various cities in Ukraine."
+    },
+    {
+      "text": "NATO-Länder sandten sofort Kampfjets, um den Luftraum von Estland und Polen zu schützen.",
+      "translated_text": "NATO countries immediately sent fighter jets to protect the airspace of Estonia and Poland."
+    },
+    {
+      "text": "Die internationale Gemeinschaft ist sehr besorgt über diese Entwicklung.",
+      "translated_text": "The international community is very concerned about this development."
+    },
+    {
+      "text": "Viele Zivilisten mussten ihre Häuser verlassen und in sicherere Gebiete fliehen.",
+      "translated_text": "Many civilians had to leave their homes and flee to safer areas."
+    },
+    {
+      "text": "Die ukrainische Regierung hat um mehr militärische Hilfe gebeten.",
+      "translated_text": "The Ukrainian government has asked for more military assistance."
+    },
+    {
+      "text": "Europäische Politiker treffen sich heute, um über eine Antwort zu diskutieren.",
+      "translated_text": "European politicians are meeting today to discuss a response."
+    },
+    {
+      "text": "Die NATO betont, dass sie bereit ist, ihre Mitgliedsländer zu verteidigen.",
+      "translated_text": "NATO emphasizes that it is ready to defend its member countries."
+    },
+    {
+      "text": "Humanitäre Organisationen arbeiten daran, den betroffenen Menschen zu helfen.",
+      "translated_text": "Humanitarian organizations are working to help the affected people."
+    },
+    {
+      "text": "Die Situation bleibt sehr gefährlich und unvorhersagbar.",
+      "translated_text": "The situation remains very dangerous and unpredictable."
+    }
+  ],
+  "key_vocab": [
+    {
+      "term": "der Angriff",
+      "translated_term": "attack",
+      "example_usage": "Russland hat heute einen großen Angriff auf die Ukraine gestartet."
+    },
+    {
+      "term": "die Streitkräfte",
+      "translated_term": "armed forces",
+      "example_usage": "Die russischen Streitkräfte griffen verschiedene Städte in der Ukraine an."
+    },
+    {
+      "term": "der Kampfjet",
+      "translated_term": "fighter jet",
+      "example_usage": "NATO-Länder sandten sofort Kampfjets, um den Luftraum zu schützen."
+    },
+    {
+      "term": "der Luftraum",
+      "translated_term": "airspace",
+      "example_usage": "NATO-Länder sandten sofort Kampfjets, um den Luftraum von Estland und Polen zu schützen."
+    },
+    {
+      "term": "die Entwicklung",
+      "translated_term": "development",
+      "example_usage": "Die internationale Gemeinschaft ist sehr besorgt über diese Entwicklung."
+    },
+    {
+      "term": "der Zivilist",
+      "translated_term": "civilian",
+      "example_usage": "Viele Zivilisten mussten ihre Häuser verlassen und in sicherere Gebiete fliehen."
+    },
+    {
+      "term": "fliehen",
+      "translated_term": "to flee",
+      "example_usage": "Viele Zivilisten mussten ihre Häuser verlassen und in sicherere Gebiete fliehen."
+    },
+    {
+      "term": "die Hilfe",
+      "translated_term": "assistance, help",
+      "example_usage": "Die ukrainische Regierung hat um mehr militärische Hilfe gebeten."
+    },
+    {
+      "term": "verteidigen",
+      "translated_term": "to defend",
+      "example_usage": "Die NATO betont, dass sie bereit ist, ihre Mitgliedsländer zu verteidigen."
+    },
+    {
+      "term": "unvorhersagbar",
+      "translated_term": "unpredictable",
+      "example_usage": "Die Situation bleibt sehr gefährlich und unvorhersagbar."
+    }
+  ],
+  "tags": [
+    {
+      "name": "Ukraine-Krieg",
+      "translated_name": "Ukraine War"
+    },
+    {
+      "name": "Internationale Politik",
+      "translated_name": "International Politics"
+    },
+    {
+      "name": "Sicherheit",
+      "translated_name": "Security"
+    }
+  ],
+  "sources": [
+    {
+      "name": "CNN Breaking News",
+      "link_url": "https://www.cnn.com/"
+    },
+    {
+      "name": "Al Jazeera World News",
+      "link_url": "https://www.aljazeera.com/"
+    }
+  ]
+}

--- a/articles/2025-09-21/trump-starmer-technologie-abkommen.json
+++ b/articles/2025-09-21/trump-starmer-technologie-abkommen.json
@@ -1,0 +1,122 @@
+{
+  "title": "Trump und Starmer schließen Technologie-Abkommen ab",
+  "translated_title": "Trump and Starmer conclude technology agreement",
+  "text": [
+    {
+      "text": "Der amerikanische Präsident Donald Trump und der britische Premierminister Keir Starmer haben ein wichtiges Technologie-Abkommen unterzeichnet.",
+      "translated_text": "American President Donald Trump and British Prime Minister Keir Starmer have signed an important technology agreement."
+    },
+    {
+      "text": "Das Abkommen umfasst Investitionen in künstliche Intelligenz und Atomkraft.",
+      "translated_text": "The agreement includes investments in artificial intelligence and nuclear power."
+    },
+    {
+      "text": "Trump sagte, dass die Reise nach Großbritannien 350 Milliarden Dollar an Geschäften gebracht hat.",
+      "translated_text": "Trump said that the trip to Great Britain brought $350 billion in deals."
+    },
+    {
+      "text": "Die beiden Politiker trafen sich in Starmers offizieller Residenz nördlich von London.",
+      "translated_text": "The two politicians met at Starmer's official residence north of London."
+    },
+    {
+      "text": "Sie diskutierten auch über die Kriege in Gaza und der Ukraine.",
+      "translated_text": "They also discussed the wars in Gaza and Ukraine."
+    },
+    {
+      "text": "Bei dem Gaza-Konflikt waren sich Trump und Starmer nicht einig.",
+      "translated_text": "On the Gaza conflict, Trump and Starmer did not agree."
+    },
+    {
+      "text": "Trump ist gegen die Anerkennung eines palästinensischen Staates durch Großbritannien.",
+      "translated_text": "Trump is against Great Britain's recognition of a Palestinian state."
+    },
+    {
+      "text": "Starmer nannte die Situation in Gaza 'unerträglich'.",
+      "translated_text": "Starmer called the situation in Gaza 'unbearable'."
+    },
+    {
+      "text": "Trotz der Meinungsverschiedenheiten betonten beide die starke Allianz zwischen den USA und Großbritannien.",
+      "translated_text": "Despite the disagreements, both emphasized the strong alliance between the USA and Great Britain."
+    },
+    {
+      "text": "Das neue Technologie-Abkommen soll das Leben der Menschen in beiden Ländern verbessern.",
+      "translated_text": "The new technology agreement should improve the lives of people in both countries."
+    }
+  ],
+  "key_vocab": [
+    {
+      "term": "das Abkommen",
+      "translated_term": "agreement",
+      "example_usage": "Das Abkommen umfasst Investitionen in künstliche Intelligenz und Atomkraft."
+    },
+    {
+      "term": "unterzeichnen",
+      "translated_term": "to sign",
+      "example_usage": "Der amerikanische Präsident Donald Trump und der britische Premierminister Keir Starmer haben ein wichtiges Technologie-Abkommen unterzeichnet."
+    },
+    {
+      "term": "die Investition",
+      "translated_term": "investment",
+      "example_usage": "Das Abkommen umfasst Investitionen in künstliche Intelligenz und Atomkraft."
+    },
+    {
+      "term": "künstliche Intelligenz",
+      "translated_term": "artificial intelligence",
+      "example_usage": "Das Abkommen umfasst Investitionen in künstliche Intelligenz und Atomkraft."
+    },
+    {
+      "term": "die Atomkraft",
+      "translated_term": "nuclear power",
+      "example_usage": "Das Abkommen umfasst Investitionen in künstliche Intelligenz und Atomkraft."
+    },
+    {
+      "term": "die Residenz",
+      "translated_term": "residence",
+      "example_usage": "Die beiden Politiker trafen sich in Starmers offizieller Residenz nördlich von London."
+    },
+    {
+      "term": "die Anerkennung",
+      "translated_term": "recognition",
+      "example_usage": "Trump ist gegen die Anerkennung eines palästinensischen Staates durch Großbritannien."
+    },
+    {
+      "term": "unerträglich",
+      "translated_term": "unbearable",
+      "example_usage": "Starmer nannte die Situation in Gaza 'unerträglich'."
+    },
+    {
+      "term": "die Meinungsverschiedenheit",
+      "translated_term": "disagreement",
+      "example_usage": "Trotz der Meinungsverschiedenheiten betonten beide die starke Allianz zwischen den USA und Großbritannien."
+    },
+    {
+      "term": "die Allianz",
+      "translated_term": "alliance",
+      "example_usage": "Trotz der Meinungsverschiedenheiten betonten beide die starke Allianz zwischen den USA und Großbritannien."
+    }
+  ],
+  "tags": [
+    {
+      "name": "USA-UK Beziehungen",
+      "translated_name": "US-UK Relations"
+    },
+    {
+      "name": "Technologie",
+      "translated_name": "Technology"
+    },
+    {
+      "name": "Gaza-Konflikt",
+      "translated_name": "Gaza Conflict"
+    }
+  ],
+  "sources": [
+    {
+      "name": "ABC News Politics",
+      "link_url": "https://abcnews.go.com/Politics/trump-leave-windsor-castle-meet-starmer-day-2/story?id=125692018"
+    },
+    {
+      "name": "CNN UK News",
+      "link_url": "https://www.cnn.com/world/united-kingdom"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
• Created 4 B1-level German news articles covering today's top stories
• Added Russia-Ukraine conflict article with NATO response details
• Added Trump-Starmer technology agreement and Gaza policy disagreements
• Added German police raids on right-wing extremist groups
• Added women's protests in Berlin parliament against budget cuts

## Test plan
- [x] All articles follow the JSON schema format in article-schema.json
- [x] Each article includes German text with sentence-by-sentence English translations
- [x] Key vocabulary includes proper German articles (der/die/das) and example usage
- [x] All tags used already exist in tags.json (no updates needed)
- [x] Articles saved under articles/2025-09-21/ directory

🤖 Generated with [Claude Code](https://claude.ai/code)